### PR TITLE
Install INTL php extension onto composer image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apk --no-cache add patch freetype-dev libjpeg-turbo-dev libpng-dev && docker
   --with-freetype \
   --with-jpeg \
   && docker-php-ext-install gd
+  && docker-php-ext-install intl
 WORKDIR /app
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["composer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM composer:2.0
-RUN apk --no-cache add patch freetype-dev libjpeg-turbo-dev libpng-dev && docker-php-ext-configure gd \
+RUN apk --no-cache add patch freetype-dev libjpeg-turbo-dev libpng-dev icu-dev && docker-php-ext-configure gd \
   --with-freetype \
   --with-jpeg \
-  && docker-php-ext-install gd
+  && docker-php-ext-install gd \
   && docker-php-ext-install intl
 WORKDIR /app
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
This is to resolve this build error

```
<html>
<body>
<!--StartFragment-->

Installing dependencies from lock file (including require-dev)
--
  | Verifying lock file contents can be installed on current platform.
  | Your lock file does not contain a compatible set of packages. Please run composer update.
  |  
  | Problem 1
  | - civicrm/civicrm-core is locked to version 5.35.2 and an update of this package was not requested.
  | - civicrm/civicrm-core 5.35.2 requires ext-intl * -> it is missing from your system. Install or enable PHP's intl extension.
  | Problem 2
  | - civicrm/civicrm-core 5.35.2 requires ext-intl * -> it is missing from your system. Install or enable PHP's intl extension.
  | - drupal/civicrm_entity 3.0.0-beta3 requires civicrm/civicrm-core ~5.0 -> satisfiable by civicrm/civicrm-core[5.35.2].
  | - drupal/civicrm_entity is locked to version 3.0.0-beta3 and an update of this package was not requested.
  |  
  | To enable extensions, verify that they are enabled in your .ini files:
  | - /usr/local/etc/php/php-cli.ini
  | - /usr/local/etc/php/conf.d/docker-php-ext-gd.ini
  | - /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini
  | - /usr/local/etc/php/conf.d/docker-php-ext-zip.ini
  | You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.

<!--EndFragment-->
</body>
</html>
```