### PR TITLE
Upgrade composer to match local-dev-setup: v2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.0
+FROM composer:2.6
 RUN apk --no-cache add patch freetype-dev libjpeg-turbo-dev libpng-dev icu-dev && docker-php-ext-configure gd \
   --with-freetype \
   --with-jpeg \


### PR DESCRIPTION
Upgrading the version of composer we use in Buildkite to v2.6, which is the same as what is used locally according to `local-dev-setup`.

Note that the PHP 8.1 build of Civi is failing due to the old version of composer we're currently using on Buildkite.