### PR TITLE
Add php mysqli extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ RUN apk --no-cache add patch freetype-dev libjpeg-turbo-dev libpng-dev icu-dev &
   --with-freetype \
   --with-jpeg \
   && docker-php-ext-install gd \
-  && docker-php-ext-install intl
+  && docker-php-ext-install intl \
+  && docker-php-ext-install mysqli
 WORKDIR /app
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["composer"]


### PR DESCRIPTION
CiviCRM 6.2 requires the php-mysqli extension. Since this is added as a composer requirement, it must be present in the composer container.

This has been tested in Buildkite and is working as expected.

I don't anticipate that there will be backwards compatibility problems - I strongly suspect it will work regardless of the Buildkite pipeline which uses it.